### PR TITLE
Update wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,6 @@ name = "cloud-storage"
 type = "webpack"
 webpack_config = "webpack.config.js"
 zone_id = ""
-private = false
 account_id = ""
 route = ""
+workers_dev = true


### PR DESCRIPTION
We don't need private anymore, and templates should deploy to workers.dev by default